### PR TITLE
Fixed missing argument in function mraa_gpio_write

### DIFF
--- a/mraa/lesson0/blink.c
+++ b/mraa/lesson0/blink.c
@@ -47,7 +47,7 @@ main(int argc, char **argv)
         // flip our value
         val = !val;
         // write the value to our gpio
-        mraa_gpio_write(val);
+        mraa_gpio_write(mygpio, val);
         // sleep(3) uses seconds
         sleep(1);
     }


### PR DESCRIPTION
The first param of mraa_gpio_write function (that specifies the context) was missing.