### PR TITLE
upm: Update sample source with new upm headers (.h -> .hpp)

### DIFF
--- a/eclipse/c++/BluemixFlameDetection.cpp
+++ b/eclipse/c++/BluemixFlameDetection.cpp
@@ -69,9 +69,9 @@
 
 #include "mraa.hpp"
 #include <iostream>
-#include <yg1006.h>
+#include <yg1006.hpp>
 #include <unistd.h>
-#include <buzzer.h>
+#include <buzzer.hpp>
 
 #include "BluemixFDAppClient.hpp"
 #include "BluemixFDDeviceClient.hpp"

--- a/eclipse/c++/BluemixSendTempData.cpp
+++ b/eclipse/c++/BluemixSendTempData.cpp
@@ -57,7 +57,7 @@ extern "C" {
 #include "mraa.hpp"
 #include "stdlib.h"
 
-#include <grove.h>
+#include <grove.hpp>
 #include <climits>
 #include <iostream>
 #include <sstream>

--- a/eclipse/c++/DisplayTemperatureOnLCD.cpp
+++ b/eclipse/c++/DisplayTemperatureOnLCD.cpp
@@ -42,7 +42,7 @@
  */
 
 #include "mraa.hpp"
-#include "grove.h"
+#include "grove.hpp"
 #include "jhd1313m1.h"
 
 #include <climits>

--- a/eclipse/c++/IoTTeam_Pleant_Health_Monitor.cpp
+++ b/eclipse/c++/IoTTeam_Pleant_Health_Monitor.cpp
@@ -27,11 +27,11 @@
 #include <sstream>
 
 #include <mraa.hpp>
-#include <grove.h>
-#include <grovemoisture.h>
+#include <grove.hpp>
+#include <grovemoisture.hpp>
 #include <mq5.h>
 #include <jhd1313m1.h>
-#include <guvas12d.h>
+#include <guvas12d.hpp>
 
 /**
  * @file

--- a/eclipse/c++/IoTTeam_Sound_Bar.cpp
+++ b/eclipse/c++/IoTTeam_Sound_Bar.cpp
@@ -27,9 +27,9 @@
 #include <sstream>
 
 #include <mraa.hpp>
-#include <grove.h>
-#include <mic.h>
-#include <my9221.h>
+#include <grove.hpp>
+#include <mic.hpp>
+#include <my9221.hpp>
 
 /**
  * @file

--- a/eclipse/c++/IoTTeam_Tan_Responsibly.cpp
+++ b/eclipse/c++/IoTTeam_Tan_Responsibly.cpp
@@ -27,10 +27,10 @@
 #include <sstream>
 
 #include <mraa.hpp>
-#include <grove.h>
+#include <grove.hpp>
 #include <jhd1313m1.h>
-#include <guvas12d.h>
-#include <buzzer.h>
+#include <guvas12d.hpp>
+#include <buzzer.hpp>
 
 /**
  * @file

--- a/eclipse/c++/LightController.cpp
+++ b/eclipse/c++/LightController.cpp
@@ -32,10 +32,10 @@
 #include <sstream>
 
 #include <mraa.hpp>
-#include <grove.h>
+#include <grove.hpp>
 #include <jhd1313m1.h>
-#include <uln200xa.h>
-#include <ttp223.h>
+#include <uln200xa.hpp>
+#include <ttp223.hpp>
 
 /**
  * @file

--- a/eclipse/c++/SmartPhotovoltaicPanelAVGExample.cpp
+++ b/eclipse/c++/SmartPhotovoltaicPanelAVGExample.cpp
@@ -29,9 +29,9 @@
 #include <unistd.h>
 
 #include <mraa.hpp>
-#include <grove.h>
+#include <grove.hpp>
 #include <jhd1313m1.h>
-#include <uln200xa.h>
+#include <uln200xa.hpp>
 
 /**
  * @file

--- a/kits/robotics/c++/Robot.cxx
+++ b/kits/robotics/c++/Robot.cxx
@@ -52,11 +52,11 @@
 #include <string>
 #include <thread>
 #include <mutex>
-#include "grovemd.h"
+#include "grovemd.hpp"
 #include "jhd1313m1.h"
-#include "rfr359f.h"
-#include "hmc5883l.h"
-#include "grovevdiv.h"
+#include "rfr359f.hpp"
+#include "hmc5883l.hpp"
+#include "grovevdiv.hpp"
 
 using namespace std;
 using namespace upm;

--- a/kits/starter/c++/VariousSensors.cpp
+++ b/kits/starter/c++/VariousSensors.cpp
@@ -38,9 +38,9 @@
  */
 
 #include "jhd1313m1.h"   // Lcd Display
-#include "grove.h"       // Button, Temp, Light, Rotary Sensors
-#include "mma7660.h"     // 3-Axis Digital Accelerometer
-#include "ttp223.h"      // Touch Sensor
+#include "grove.hpp"       // Button, Temp, Light, Rotary Sensors
+#include "mma7660.hpp"     // 3-Axis Digital Accelerometer
+#include "ttp223.hpp"      // Touch Sensor
 
 #include <unistd.h>
 #include <iostream>

--- a/kits/transportation-safety/c++/VehicleFleetTracker.cpp
+++ b/kits/transportation-safety/c++/VehicleFleetTracker.cpp
@@ -61,11 +61,11 @@
 #include <string.h>		/* string */
 #include <time.h>		/* time */
 #include <thread>		/* threading */
-#include "ublox6.h"		/* gps */
+#include "ublox6.hpp"		/* gps */
 #include "jhd1313m1.h"	/* lcd */
-#include "rfr359f.h"	/* distance interrupter */
-#include "rpr220.h"		/* reflective sensor */
-#include "grove.h"		/* led */
+#include "rfr359f.hpp"	/* distance interrupter */
+#include "rpr220.hpp"		/* reflective sensor */
+#include "grove.hpp"		/* led */
 
 using namespace std;
 


### PR DESCRIPTION
UPM C++ headers have been renamed to make room for adding C sources.
Header files changed from .h to .hpp.  Updating sample source to
work with the new UPM header names