### PR TITLE
Cloud example: remove support for Joule

### DIFF
--- a/azure-amqp/sample.json
+++ b/azure-amqp/sample.json
@@ -12,6 +12,12 @@
          "mraa",
          "upm",
          "Azure IoT SDK"
+      ],
+      "compatible":[
+         "Edison",
+         "MinnowBoard MAX",
+         "Gateway 32-Bit",
+         "Gateway 64-Bit"
       ]
    },
    "additional_fields":[

--- a/azure-http/sample.json
+++ b/azure-http/sample.json
@@ -12,6 +12,12 @@
          "mraa",
          "upm",
          "Azure IoT SDK"
+      ],
+      "compatible":[
+         "Edison",
+         "MinnowBoard MAX",
+         "Gateway 32-Bit",
+         "Gateway 64-Bit"
       ]
    },
    "additional_fields":[

--- a/azure-mqtt/sample.json
+++ b/azure-mqtt/sample.json
@@ -12,6 +12,12 @@
          "mraa",
          "upm",
          "Azure IoT SDK"
+      ],
+      "compatible":[
+         "Edison",
+         "MinnowBoard MAX",
+         "Gateway 32-Bit",
+         "Gateway 64-Bit"
       ]
    },
    "additional_fields":[

--- a/bluemix-flame-detect/sample.json
+++ b/bluemix-flame-detect/sample.json
@@ -13,6 +13,12 @@
          "mraa",
          "upm",
          "paho"
+      ],
+      "compatible":[
+         "Edison",
+         "MinnowBoard MAX",
+         "Gateway 32-Bit",
+         "Gateway 64-Bit"
       ]
    },
    "additional_fields":[

--- a/bluemix-quickstart/sample.json
+++ b/bluemix-quickstart/sample.json
@@ -13,6 +13,12 @@
          "mraa",
          "upm",
          "paho"
+      ],
+      "compatible":[
+         "Edison",
+         "MinnowBoard MAX",
+         "Gateway 32-Bit",
+         "Gateway 64-Bit"
       ]
    },
    "additional_fields":[


### PR DESCRIPTION
ISS IoT do not have the Azure SDK and IBM Bluemix included for the Joule
Platform.
In order to not have unbuildable examples, the support is removed.

Signed-off-by: Thomas Lyet <thomas.lyet@intel.com>