### PR TITLE
Removed Joule support from Maven examples 

### DIFF
--- a/analog-in/maven/src/main/java/iotdk/example/AnalogIn.java
+++ b/analog-in/maven/src/main/java/iotdk/example/AnalogIn.java
@@ -55,8 +55,7 @@ public class AnalogIn {
         Platform platform = mraa.getPlatformType();
         if (platform != Platform.INTEL_GALILEO_GEN1 &&
                 platform != Platform.INTEL_GALILEO_GEN2 &&
-                platform != Platform.INTEL_EDISON_FAB_C &&
-                platform != Platform.INTEL_GT_TUCHUCK) {
+                platform != Platform.INTEL_EDISON_FAB_C) {
             System.err.println("Unsupported platform, exiting");
             return;
         }

--- a/digital-in/maven/src/main/java/iotdk/example/DigitalIn.java
+++ b/digital-in/maven/src/main/java/iotdk/example/DigitalIn.java
@@ -54,8 +54,7 @@ public class DigitalIn {
         Platform platform = mraa.getPlatformType();
         if (platform != Platform.INTEL_GALILEO_GEN1 &&
                 platform != Platform.INTEL_GALILEO_GEN2 &&
-                platform != Platform.INTEL_EDISON_FAB_C &&
-                platform != Platform.INTEL_GT_TUCHUCK) {
+                platform != Platform.INTEL_EDISON_FAB_C) {
             System.err.println("Unsupported platform, exiting");
             return;
         }

--- a/digital-out/maven/src/main/java/iotdk/example/DigitalOut.java
+++ b/digital-out/maven/src/main/java/iotdk/example/DigitalOut.java
@@ -54,8 +54,7 @@ public class DigitalOut {
         Platform platform = mraa.getPlatformType();
         if (platform != Platform.INTEL_GALILEO_GEN1 &&
                 platform != Platform.INTEL_GALILEO_GEN2 &&
-                platform != Platform.INTEL_EDISON_FAB_C &&
-                platform != Platform.INTEL_GT_TUCHUCK) {
+                platform != Platform.INTEL_EDISON_FAB_C) {
             System.err.println("Unsupported platform, exiting");
             return;
         }

--- a/interrupt/maven/src/main/java/iotdk/example/Interrupt.java
+++ b/interrupt/maven/src/main/java/iotdk/example/Interrupt.java
@@ -74,8 +74,7 @@ public class Interrupt {
         Platform platform = mraa.getPlatformType();
         if (platform != Platform.INTEL_GALILEO_GEN1 &&
                 platform != Platform.INTEL_GALILEO_GEN2 &&
-                platform != Platform.INTEL_EDISON_FAB_C &&
-                platform != Platform.INTEL_GT_TUCHUCK) {
+                platform != Platform.INTEL_EDISON_FAB_C) {
             System.err.println("Unsupported platform, exiting");
             return;
         }

--- a/onboard-blink/maven/src/main/java/iotdk/example/OnboardLedBlink.java
+++ b/onboard-blink/maven/src/main/java/iotdk/example/OnboardLedBlink.java
@@ -59,8 +59,6 @@ public class OnboardLedBlink {
             pin = new Gpio(13);
         else if (platform == Platform.INTEL_EDISON_FAB_C)
             pin = new Gpio(13);
-        else if (platform == Platform.INTEL_GT_TUCHUCK)
-            pin = new Gpio(100);
 
         // set the pin as output
         if (pin == null) {

--- a/pwm/maven/src/main/java/iotdk/example/PWM.java
+++ b/pwm/maven/src/main/java/iotdk/example/PWM.java
@@ -55,8 +55,7 @@ public class PWM {
     Platform platform = mraa.getPlatformType();
     if (platform != Platform.INTEL_GALILEO_GEN1 &&
         platform != Platform.INTEL_GALILEO_GEN2 &&
-        platform != Platform.INTEL_EDISON_FAB_C &&
-        platform != Platform.INTEL_GT_TUCHUCK) {
+        platform != Platform.INTEL_EDISON_FAB_C) {
       System.err.println("Unsupported platform, exiting");
       return;
     }


### PR DESCRIPTION
As we don't support the Joule platform yet with maven I removed the support for it from the examples.

Signed-off-by: Marc Ernst <marc.ernst@intel.com>