### PR TITLE
Iss 2528 (rebased)

### DIFF
--- a/up2-leds/c/up2-leds.c
+++ b/up2-leds/c/up2-leds.c
@@ -84,7 +84,7 @@ int main()
             "Running it on different platforms will likely require code changes!\n");
     }
 
-    if (strcmp(mraa_get_version(), "v1.9.0")) {
+    if (strcmp(mraa_get_version(), "v1.9.0") < 0) {
         fprintf(stderr,"You need MRAA version 1.9.0 or newer to run this sample!\n");
         return 1;
     }


### PR DESCRIPTION
The base of ISS-2528 is changed to iss2019-update1 comparing to the previous PR